### PR TITLE
NOTASK: cloudflare dns record deletion is broken on community.generic 10.3.0 or earlier

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -1,7 +1,7 @@
 ---
 namespace: damex
 name: cloudflare
-version: 1.0.4
+version: 1.0.5
 readme: README.md
 authors:
   - Roman Kuzmitskii <ansible@damex.org>
@@ -13,5 +13,5 @@ tags:
 repository: https://github.com/damex/ansible-collections-cloudflare
 issues: https://github.com/damex/ansible-collections-cloudflare/issues
 dependencies:
-  community.general: "*"
+  community.general: ">=10.3.1"
   community.crypto: "*"


### PR DESCRIPTION
have to require 10.3.1 or later for cloudflare dns. we didn't require specific version before